### PR TITLE
fix(core): ext globs should use **/*.ext otherwise **.ext

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "clean": "rm -rf lib",
     "cp": "cp src/config/hlink.config.tpl lib/config/hlink.config.tpl",
     "build": "npm run clean && tsc && npm run cp",
+    "dev": "npm run clean && tsc -w",
     "prepublishOnly": "npm run build && vitest run"
   },
   "files": [

--- a/packages/core/src/__tests__/config/format.spec.ts
+++ b/packages/core/src/__tests__/config/format.spec.ts
@@ -85,7 +85,7 @@ describe('format test', () => {
       {
         "exclude": [],
         "include": [
-          "**.mkv",
+          "**/*.mkv",
         ],
         "pathsMapping": {
           "/a": "/b",

--- a/packages/core/src/__tests__/utils/getGlobs.spec.ts
+++ b/packages/core/src/__tests__/utils/getGlobs.spec.ts
@@ -12,8 +12,8 @@ describe('getGlobs test', () => {
       })
     ).toMatchInlineSnapshot(`
       [
-        "**.mkv",
-        "**.mp4",
+        "**/*.mkv",
+        "**/*.mp4",
       ]
     `)
   })
@@ -38,8 +38,8 @@ describe('getGlobs test', () => {
     ).toMatchInlineSnapshot(`
       [
         "**/a/**",
-        "**.mkv",
-        "**.mp4",
+        "**/*.mkv",
+        "**/*.mp4",
       ]
     `)
   })
@@ -56,8 +56,8 @@ describe('getGlobs test', () => {
   test('should be passed with exts array string', () => {
     expect(getGlobs(['ext3', 'ext2'])).toMatchInlineSnapshot(`
       [
-        "**.ext3",
-        "**.ext2",
+        "**/*.ext3",
+        "**/*.ext2",
       ]
     `)
   })

--- a/packages/core/src/utils/getGlobs.ts
+++ b/packages/core/src/utils/getGlobs.ts
@@ -16,7 +16,7 @@ const getGlobs = (
   let { globs, exts } = options || {}
   globs = globs || []
   if (exts) {
-    globs = globs.concat(exts.map((ext) => `**.${ext}`))
+    globs = globs.concat(exts.map((ext) => `**/*.${ext}`))
   }
   if (!globs.length) {
     globs = globs.concat(defaultGlobs)

--- a/packages/core/src/utils/supported.ts
+++ b/packages/core/src/utils/supported.ts
@@ -3,6 +3,7 @@ import micromatch from 'micromatch'
 function supported(path: string, include: string[], exclude: string[]) {
   return micromatch.isMatch(path.toLowerCase(), include, {
     ignore: exclude,
+    nocase: true,
   })
 }
 


### PR DESCRIPTION
详情见：https://github.com/micromatch/picomatch/issues/99